### PR TITLE
Added HC metrics fallback attribute

### DIFF
--- a/Network Interfaces Report/network-interfaces-report.json
+++ b/Network Interfaces Report/network-interfaces-report.json
@@ -1,34 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_OPENNMS_HORIZON PM",
-      "label": "OpenNMS Horizon PM",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "opennms-helm-performance-datasource",
-      "pluginName": "OpenNMS Performance"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.2.4"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "opennms-helm-performance-datasource",
-      "name": "OpenNMS Performance",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -46,8 +16,8 @@
   "editable": true,
   "gnetId": 5053,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1539768709443,
+  "id": 4,
+  "iteration": 1542614796273,
   "links": [],
   "panels": [
     {
@@ -55,7 +25,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "OpenNMS Performance",
       "description": "The total number of bits received and transmitted on the interface, including framing characters.",
       "fill": 1,
       "gridPos": {
@@ -97,6 +67,7 @@
       "targets": [
         {
           "attribute": "ifHCInOctets",
+          "fallbackAttribute": "ifInOctets",
           "hide": true,
           "label": "$index_in",
           "nodeId": "$node",
@@ -112,6 +83,7 @@
         },
         {
           "attribute": "ifHCOutOctets",
+          "fallbackAttribute": "ifOutOctets",
           "hide": true,
           "label": "$index_out",
           "nodeId": "$node",
@@ -172,7 +144,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "OpenNMS Performance",
       "description": "Network interface utilisation.",
       "fill": 1,
       "gridPos": {
@@ -290,7 +262,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "OpenNMS Performance",
       "description": "For packet-oriented interfaces, the number of inbound or outbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol.",
       "fill": 1,
       "gridPos": {
@@ -392,7 +364,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "OpenNMS Performance",
       "description": "The number of outbound and inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol. One possible reason for discarding such a packet could be to free up buffer space.",
       "fill": 1,
       "gridPos": {
@@ -494,7 +466,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "OpenNMS Performance",
       "description": "Number of received or transmitted Unicast, Broadcast and Multicast packets.",
       "fill": 1,
       "gridPos": {
@@ -637,8 +609,12 @@
     "list": [
       {
         "allValue": null,
-        "current": {},
-        "datasource": "${DS_OPENNMS_HORIZON PM}",
+        "current": {
+          "tags": [],
+          "text": "isp",
+          "value": "network:isp"
+        },
+        "datasource": "OpenNMS Performance",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -648,6 +624,7 @@
         "query": "nodeFilter(nodeSysOid like '.1.3.6.1.4.1.%')",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -657,8 +634,11 @@
       },
       {
         "allValue": null,
-        "current": {},
-        "datasource": "${DS_OPENNMS_HORIZON PM}",
+        "current": {
+          "text": "interfaceSnmp[br0-bcee7b34a090]",
+          "value": "interfaceSnmp[br0-bcee7b34a090]"
+        },
+        "datasource": "OpenNMS Performance",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -668,6 +648,7 @@
         "query": "nodeResources($node)",
         "refresh": 1,
         "regex": "^interfaceSnmp\\[.*",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -709,5 +690,5 @@
   "timezone": "",
   "title": "OpenNMS Network Interfaces Report",
   "uid": "5A-Imb7mz",
-  "version": 3
+  "version": 2
 }

--- a/Network Interfaces Report/network-interfaces-report.json
+++ b/Network Interfaces Report/network-interfaces-report.json
@@ -1,20 +1,11 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_OPENNMS_HORIZON PM",
-      "label": "OpenNMS Horizon PM",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "opennms-helm-performance-datasource",
-      "pluginName": "OpenNMS Performance"
-    }
-  ],
+  "__inputs": [],
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.2.4"
+      "version": "5.3.4"
     },
     {
       "type": "panel",
@@ -47,7 +38,7 @@
   "gnetId": 5053,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1539768709443,
+  "iteration": 1543870778775,
   "links": [],
   "panels": [
     {
@@ -55,7 +46,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "$instance",
       "description": "The total number of bits received and transmitted on the interface, including framing characters.",
       "fill": 1,
       "gridPos": {
@@ -113,7 +104,7 @@
         },
         {
           "attribute": "ifHCOutOctets",
-          "fallbackAttribute": "ifOutOctets",          
+          "fallbackAttribute": "ifOutOctets",
           "hide": true,
           "label": "$index_out",
           "nodeId": "$node",
@@ -174,7 +165,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "$instance",
       "description": "Network interface utilisation.",
       "fill": 1,
       "gridPos": {
@@ -294,7 +285,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "$instance",
       "description": "For packet-oriented interfaces, the number of inbound or outbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol.",
       "fill": 1,
       "gridPos": {
@@ -396,7 +387,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "$instance",
       "description": "The number of outbound and inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol. One possible reason for discarding such a packet could be to free up buffer space.",
       "fill": 1,
       "gridPos": {
@@ -498,7 +489,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_OPENNMS_HORIZON PM}",
+      "datasource": "$instance",
       "description": "Number of received or transmitted Unicast, Broadcast and Multicast packets.",
       "fill": 1,
       "gridPos": {
@@ -540,7 +531,7 @@
         {
           "aggregation": "AVERAGE",
           "attribute": "ifHCInUcastPkts",
-          "fallbackAttribute": "ifInUcastPkts",          
+          "fallbackAttribute": "ifInUcastPkts",
           "label": "In Unicast $node $interface",
           "nodeId": "$node",
           "refId": "A",
@@ -550,7 +541,7 @@
         {
           "aggregation": "AVERAGE",
           "attribute": "ifHCInMulticastPkts",
-          "fallbackAttribute": "ifInMulticastPkts",          
+          "fallbackAttribute": "ifInMulticastPkts",
           "label": "In Multicast on $node $interface",
           "nodeId": "$node",
           "refId": "B",
@@ -646,9 +637,25 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "tags": [],
+          "text": "OpenNMS FUL Performance",
+          "value": "OpenNMS FUL Performance"
+        },
+        "hide": 0,
+        "label": "OpenNMS Instance",
+        "name": "instance",
+        "options": [],
+        "query": "opennms-helm-performance-datasource",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_OPENNMS_HORIZON PM}",
+        "datasource": "$instance",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -658,6 +665,7 @@
         "query": "nodeFilter(nodeSysOid like '.1.3.6.1.4.1.%')",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -668,7 +676,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_OPENNMS_HORIZON PM}",
+        "datasource": "$instance",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -678,6 +686,7 @@
         "query": "nodeResources($node)",
         "refresh": 1,
         "regex": "^interfaceSnmp\\[.*",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -719,5 +728,5 @@
   "timezone": "",
   "title": "OpenNMS Network Interfaces Report",
   "uid": "5A-Imb7mz",
-  "version": 3
+  "version": 4
 }

--- a/Network Interfaces Report/network-interfaces-report.json
+++ b/Network Interfaces Report/network-interfaces-report.json
@@ -1,4 +1,34 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_OPENNMS_HORIZON PM",
+      "label": "OpenNMS Horizon PM",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "opennms-helm-performance-datasource",
+      "pluginName": "OpenNMS Performance"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.2.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "opennms-helm-performance-datasource",
+      "name": "OpenNMS Performance",
+      "version": "1.0.0"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -16,8 +46,8 @@
   "editable": true,
   "gnetId": 5053,
   "graphTooltip": 0,
-  "id": 4,
-  "iteration": 1542614796273,
+  "id": null,
+  "iteration": 1539768709443,
   "links": [],
   "panels": [
     {
@@ -25,7 +55,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "OpenNMS Performance",
+      "datasource": "${DS_OPENNMS_HORIZON PM}",
       "description": "The total number of bits received and transmitted on the interface, including framing characters.",
       "fill": 1,
       "gridPos": {
@@ -83,7 +113,7 @@
         },
         {
           "attribute": "ifHCOutOctets",
-          "fallbackAttribute": "ifOutOctets",
+          "fallbackAttribute": "ifOutOctets",          
           "hide": true,
           "label": "$index_out",
           "nodeId": "$node",
@@ -144,7 +174,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "OpenNMS Performance",
+      "datasource": "${DS_OPENNMS_HORIZON PM}",
       "description": "Network interface utilisation.",
       "fill": 1,
       "gridPos": {
@@ -186,6 +216,7 @@
       "targets": [
         {
           "attribute": "ifHCInOctets",
+          "fallbackAttribute": "ifInOctets",
           "hide": true,
           "label": "$index_in",
           "nodeId": "$node",
@@ -194,7 +225,8 @@
           "type": "attribute"
         },
         {
-          "attribute": "ifOutOctets",
+          "attribute": "ifHCOutOctets",
+          "fallbackAttribute": "ifOutOctets",
           "hide": true,
           "label": "$index_out",
           "nodeId": "$node",
@@ -262,7 +294,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "OpenNMS Performance",
+      "datasource": "${DS_OPENNMS_HORIZON PM}",
       "description": "For packet-oriented interfaces, the number of inbound or outbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol.",
       "fill": 1,
       "gridPos": {
@@ -364,7 +396,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "OpenNMS Performance",
+      "datasource": "${DS_OPENNMS_HORIZON PM}",
       "description": "The number of outbound and inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol. One possible reason for discarding such a packet could be to free up buffer space.",
       "fill": 1,
       "gridPos": {
@@ -466,7 +498,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "OpenNMS Performance",
+      "datasource": "${DS_OPENNMS_HORIZON PM}",
       "description": "Number of received or transmitted Unicast, Broadcast and Multicast packets.",
       "fill": 1,
       "gridPos": {
@@ -508,6 +540,7 @@
         {
           "aggregation": "AVERAGE",
           "attribute": "ifHCInUcastPkts",
+          "fallbackAttribute": "ifInUcastPkts",          
           "label": "In Unicast $node $interface",
           "nodeId": "$node",
           "refId": "A",
@@ -517,6 +550,7 @@
         {
           "aggregation": "AVERAGE",
           "attribute": "ifHCInMulticastPkts",
+          "fallbackAttribute": "ifInMulticastPkts",          
           "label": "In Multicast on $node $interface",
           "nodeId": "$node",
           "refId": "B",
@@ -526,6 +560,7 @@
         {
           "aggregation": "AVERAGE",
           "attribute": "ifHCInBroadcastPkts",
+          "fallbackAttribute": "ifInBroadcastPkts",
           "label": "In Broadcast on $node $interface",
           "nodeId": "$node",
           "refId": "C",
@@ -535,6 +570,7 @@
         {
           "aggregation": "AVERAGE",
           "attribute": "ifHCOutUcastPkts",
+          "fallbackAttribute": "ifOutUcastPkts",
           "label": "Out Unicast $node $interface",
           "nodeId": "$node",
           "refId": "D",
@@ -544,6 +580,7 @@
         {
           "aggregation": "AVERAGE",
           "attribute": "ifHCOutMulticastPkt",
+          "fallbackAttribute": "ifOutMulticastPkt",
           "label": "Out Multicast on $node $interface",
           "nodeId": "$node",
           "refId": "E",
@@ -553,6 +590,7 @@
         {
           "aggregation": "AVERAGE",
           "attribute": "ifHCOutBroadcastPkt",
+          "fallbackAttribute": "ifOutBroadcastPkt",
           "label": "Out Broadcast on $node $interface",
           "nodeId": "$node",
           "refId": "F",
@@ -609,12 +647,8 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "isp",
-          "value": "network:isp"
-        },
-        "datasource": "OpenNMS Performance",
+        "current": {},
+        "datasource": "${DS_OPENNMS_HORIZON PM}",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -624,7 +658,6 @@
         "query": "nodeFilter(nodeSysOid like '.1.3.6.1.4.1.%')",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -634,11 +667,8 @@
       },
       {
         "allValue": null,
-        "current": {
-          "text": "interfaceSnmp[br0-bcee7b34a090]",
-          "value": "interfaceSnmp[br0-bcee7b34a090]"
-        },
-        "datasource": "OpenNMS Performance",
+        "current": {},
+        "datasource": "${DS_OPENNMS_HORIZON PM}",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -648,7 +678,6 @@
         "query": "nodeResources($node)",
         "refresh": 1,
         "regex": "^interfaceSnmp\\[.*",
-        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -690,5 +719,5 @@
   "timezone": "",
   "title": "OpenNMS Network Interfaces Report",
   "uid": "5A-Imb7mz",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
Since legacy MIB2 metrics were removed (or separated) from the default ONMS datacolleciton, we should add the legacy ones as fallback attribute to make sure, one of them will work.